### PR TITLE
escape field names

### DIFF
--- a/lib/Fixtures.js
+++ b/lib/Fixtures.js
@@ -73,7 +73,7 @@ Fixtures.prototype._insertDB = function(conn, tablename, fixture, cb) {
       val += ",";
     }
     first = false
-    sql += key;
+    sql += mysql.escapeId(key);
     val += "?";
     values.push(fixture[key]);
   }


### PR DESCRIPTION
Guard against MYSQL reserved words as field names.

``` sql
insert into my_table (join) values(true) -- generates ER_PARSE_ERROR
```

``` sql
insert into my_table (`join`) values(true) -- escaped reserved words parse without error
```
